### PR TITLE
Basic expression evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Lets not commit Vim swp files.
+*.swp

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"log"
+
+	"github.com/eriktate/go-decide"
+)
+
+func main() {
+	log.Println("TESTING EXPR EVALUATION")
+
+	left := decide.NewBaseExpr(10)
+	right := decide.NewBaseExpr(11)
+
+	eq := decide.NewExpr(left, right, decide.Eq)
+	neq := decide.NewExpr(left, right, decide.Neq)
+	gt := decide.NewExpr(left, right, decide.Gt)
+	lt := decide.NewExpr(left, right, decide.Lt)
+
+	log.Printf("%d = %d?", left.Evaluate(), right.Evaluate())
+	log.Printf("Result: %t", decide.Decide(eq))
+
+	log.Printf("%d != %d?", left.Evaluate(), right.Evaluate())
+	log.Printf("Result: %t", decide.Decide(neq))
+
+	log.Printf("%d > %d?", left.Evaluate(), right.Evaluate())
+	log.Printf("Result: %t", decide.Decide(gt))
+
+	log.Printf("%d < %d?", left.Evaluate(), right.Evaluate())
+	log.Printf("Result: %t", decide.Decide(lt))
+
+	log.Println("Trying something more complicated...")
+
+	testString := decide.NewBaseExpr("Hello sweetie")
+	stringExpr := decide.NewExpr(testString, decide.NewBaseExpr("Hello sweetie"), decide.Eq)
+	combinedExpr := decide.NewExpr(neq, stringExpr, decide.And)
+
+	log.Printf("Result of combined: %t", decide.Decide(combinedExpr))
+}

--- a/decide.go
+++ b/decide.go
@@ -1,0 +1,80 @@
+package decide
+
+import "log"
+
+// An Expression is anything that can evaluate to a value.
+type Expression interface {
+	Evaluate() interface{}
+}
+
+// A StructScanner is a struct that implements the Scan function for retrieving shallow or deeply nested values.
+type StructScanner interface {
+	Scan(path string) interface{}
+}
+
+// Operator represents the function signature for some operator function.
+type Operator func(left, right Expression) bool
+
+// Expr represents that base of what every rule should boil down to. An (optional) left expression, a right expression
+// and some operator to compare the two sides.
+type Expr struct {
+	left  Expression
+	right Expression
+	op    Operator
+
+	single bool
+}
+
+// A StructExpr is a special type of expression that knows what names map to specific structs. It uses this information
+// to return some value from a path it's passed.
+type StructExpr struct {
+	structs map[string]StructScanner
+	path    string
+}
+
+// Primitive is just a container for some primitive value that implements the Expression interface.
+// Reflection in the ops list will figure out what to do with the underlying concrete value.
+type Primitive struct {
+	Val interface{}
+}
+
+// Evaluate runs the left and right expressions through the operator function and returns their result.
+func (e *Expr) Evaluate() interface{} {
+	return e.op(e.left, e.right)
+}
+
+func (s *StructExpr) Evaluate() interface{} {
+	// Parse out struct name here.
+	head := ""
+	tail := ""
+	return s.structs[head].Scan(tail)
+}
+
+func (b *Primitive) Evaluate() interface{} {
+	return b.Val
+}
+
+func NewExpr(left, right Expression, op Operator) *Expr {
+	return &Expr{
+		left:  left,
+		right: right,
+		op:    op,
+	}
+}
+
+func NewPrimitive(val interface{}) *Primitive {
+	return &Primitive{Val: val}
+}
+
+// Decide is meant to kick off a decision using a root Expr.
+func Decide(expr *Expr) bool {
+	eval := expr.Evaluate()
+	result, ok := eval.(bool)
+	// For now assume that results that aren't bools evaluate to false.
+	if !ok {
+		log.Println("Result wasn't a bool!")
+		return false
+	}
+
+	return result
+}

--- a/ops.go
+++ b/ops.go
@@ -1,0 +1,93 @@
+package decide
+
+import "reflect"
+
+func Eq(left, right Expression) bool {
+	return left.Evaluate() == right.Evaluate()
+}
+
+func Neq(left, right Expression) bool {
+	return left.Evaluate() != right.Evaluate()
+}
+
+func Gt(leftExpr, rightExpr Expression) bool {
+	left := leftExpr.Evaluate()
+	right := rightExpr.Evaluate()
+
+	if reflect.TypeOf(left) != reflect.TypeOf(right) {
+		return false
+	}
+
+	switch left.(type) {
+	case int:
+		return left.(int) > right.(int)
+	case float32:
+		return left.(float32) > right.(float32)
+	case float64:
+		return left.(float64) > right.(float64)
+	case string:
+		return left.(string) > right.(string)
+	default:
+		return false
+	}
+}
+
+func Lt(leftExpr, rightExpr Expression) bool {
+	left := leftExpr.Evaluate()
+	right := rightExpr.Evaluate()
+
+	if reflect.TypeOf(left) != reflect.TypeOf(right) {
+		return false
+	}
+
+	switch left.(type) {
+	case int:
+		return left.(int) < right.(int)
+	case float32:
+		return left.(float32) < right.(float32)
+	case float64:
+		return left.(float64) < right.(float64)
+	case string:
+		return left.(string) < right.(string)
+	default:
+		return false
+	}
+}
+
+func Gteq(left, right Expression) bool {
+	return Gt(left, right) || Eq(left, right)
+}
+
+func Lteq(left, right Expression) bool {
+	return Lt(left, right) || Eq(left, right)
+}
+
+func And(leftExpr, rightExpr Expression) bool {
+	// If the two expressions we're given don't evaluate to bools, return false
+	left, ok := leftExpr.Evaluate().(bool)
+	if !ok {
+		return false
+	}
+
+	right, ok := rightExpr.Evaluate().(bool)
+	if !ok {
+		return false
+	}
+
+	return left && right
+}
+
+func Or(leftExpr, rightExpr Expression) bool {
+	// If the two expressions we're given don't evaluate to bools, return false
+	left, ok := leftExpr.Evaluate().(bool)
+	if !ok {
+		return false
+	}
+
+	right, ok := rightExpr.Evaluate().(bool)
+	if !ok {
+		return false
+	}
+
+	return left || right
+}

--- a/ops_test.go
+++ b/ops_test.go
@@ -1,0 +1,158 @@
+package decide_test
+
+import (
+	"log"
+	"testing"
+
+	"github.com/eriktate/go-decide"
+)
+
+func Test_Eq(t *testing.T) {
+	// SETUP FOR SUCCESS
+	log.Println("SETTING UP FOR EQ SUCCESS")
+	left := decide.NewPrimitive(10)
+	right := decide.NewPrimitive(10)
+
+	// TEST FOR SUCCESS
+	log.Println("TESTING 10 == 10")
+	result := decide.Eq(left, right)
+
+	// ASSERT FOR SUCCESS
+	log.Printf("RESULT WAS %t", result)
+	if !result {
+		t.Errorf("Truthy expression resulted in false")
+	}
+
+	// SETUP FOR FAILURE
+	log.Println("SETTING UP FOR EQ FAILURE")
+	left = decide.NewPrimitive(13)
+
+	// TEST FAILURE
+	log.Println("TESTING 13 == 10")
+	result = decide.Eq(left, right)
+
+	// ASSERT FAILURE
+	log.Printf("RESULT WAS %t", result)
+	if result {
+		t.Errorf("Falsey expression resulted in true")
+	}
+}
+
+func Test_Neq(t *testing.T) {
+	// SETUP FOR SUCCESS
+	log.Println("SETTING UP FOR NEQ SUCCESS")
+	left := decide.NewPrimitive(10)
+	right := decide.NewPrimitive(10)
+
+	// TEST FOR SUCCESS
+	log.Println("TESTING 10 != 10")
+	result := decide.Neq(left, right)
+
+	// ASSERT FOR SUCCESS
+	log.Printf("RESULT WAS %t", result)
+	if result {
+		t.Errorf("Falsey expression resulted in true")
+	}
+
+	// SETUP FOR FAILURE
+	log.Println("SETTING UP FOR NEQ FAILURE")
+	left = decide.NewPrimitive(13)
+
+	// TEST FAILURE
+	log.Println("TESTING 13 != 10")
+	result = decide.Neq(left, right)
+
+	// ASSERT FAILURE
+	log.Printf("RESULT WAS %t", result)
+	if !result {
+		t.Errorf("Truthy expression resulted in false")
+	}
+}
+
+func Test_Gt(t *testing.T) {
+	// SETUP FOR SUCCESS
+	log.Println("SETTING UP FOR GT SUCCESS")
+	leftInt := decide.NewPrimitive(10)
+	rightInt := decide.NewPrimitive(9)
+	leftFloat := decide.NewPrimitive(10.5)
+	rightFloat := decide.NewPrimitive(10.2)
+	leftString := decide.NewPrimitive("abcd")
+	rightString := decide.NewPrimitive("abc")
+
+	// TEST FOR SUCCESS
+	log.Println("TESTING GT FOR SUCCESS")
+	resultInt := decide.Gt(leftInt, rightInt)
+	resultFloat := decide.Gt(leftFloat, rightFloat)
+	resultString := decide.Gt(leftString, rightString)
+
+	// ASSERT FOR SUCCESS
+	log.Printf("RESULT WAS Int: %t, Float: %t, String: %t", resultInt, resultFloat, resultString)
+	if !resultInt || !resultFloat || !resultString {
+		t.Errorf("Truthy expression resulted in false.")
+	}
+
+	// SETUP FOR FAILURE
+	log.Println("SETTING UP FOR GT FAILURE")
+	leftInt = decide.NewPrimitive(9)
+	rightInt = decide.NewPrimitive(10)
+	leftFloat = decide.NewPrimitive(10.2)
+	rightFloat = decide.NewPrimitive(10.5)
+	leftString = decide.NewPrimitive("abc")
+	rightString = decide.NewPrimitive("abcd")
+
+	// TEST FOR FAILURE
+	log.Println("TESTING GT FAILURE")
+	resultInt = decide.Gt(leftInt, rightInt)
+	resultFloat = decide.Gt(leftFloat, rightFloat)
+	resultString = decide.Gt(leftString, rightString)
+
+	// ASSERT FOR FAILURE
+	log.Printf("RESULT WAS Int: %t, Float: %t, String: %t", resultInt, resultFloat, resultString)
+	if resultInt || resultFloat || resultString {
+		t.Errorf("Falsey expression resulted in true.")
+	}
+}
+
+func Test_Lt(t *testing.T) {
+	// SETUP FOR FAILURE
+	log.Println("SETTING UP FOR LT FAILURE")
+	leftInt := decide.NewPrimitive(10)
+	rightInt := decide.NewPrimitive(9)
+	leftFloat := decide.NewPrimitive(10.5)
+	rightFloat := decide.NewPrimitive(10.2)
+	leftString := decide.NewPrimitive("abcd")
+	rightString := decide.NewPrimitive("abc")
+
+	// TEST FOR FAILURE
+	log.Println("TESTING GT FOR FAILURE")
+	resultInt := decide.Lt(leftInt, rightInt)
+	resultFloat := decide.Lt(leftFloat, rightFloat)
+	resultString := decide.Lt(leftString, rightString)
+
+	// ASSERT FOR FAILURE
+	log.Printf("RESULT WAS Int: %t, Float: %t, String: %t", resultInt, resultFloat, resultString)
+	if resultInt || resultFloat || resultString {
+		t.Errorf("Falsey expression resulted in true.")
+	}
+
+	// SETUP FOR SUCCESS
+	log.Println("SETTING UP FOR LT SUCCESS")
+	leftInt = decide.NewPrimitive(9)
+	rightInt = decide.NewPrimitive(10)
+	leftFloat = decide.NewPrimitive(10.2)
+	rightFloat = decide.NewPrimitive(10.5)
+	leftString = decide.NewPrimitive("abc")
+	rightString = decide.NewPrimitive("abcd")
+
+	// TEST FOR SUCCESS
+	log.Println("TESTING LT SUCCESS")
+	resultInt = decide.Lt(leftInt, rightInt)
+	resultFloat = decide.Lt(leftFloat, rightFloat)
+	resultString = decide.Lt(leftString, rightString)
+
+	// ASSERT FOR SUCCESS
+	log.Printf("RESULT WAS Int: %t, Float: %t, String: %t", resultInt, resultFloat, resultString)
+	if !resultInt || !resultFloat || !resultString {
+		t.Errorf("Truthy expression resulted in false.")
+	}
+}


### PR DESCRIPTION
This PR adds basic expression evaluation. Nested expressions are also handled here. The API for initiating decisions will likely change in the future, but for now you just grab a pointer to the root Expr struct and call Decide.

```go
// left and right can be other Exprs with sub expressions.
expr := decide.NewExpr(left, right, op)
result := decide.Decide(expr)
```