### PR TITLE
Adding expression parser

### DIFF
--- a/decide.go
+++ b/decide.go
@@ -43,6 +43,30 @@ func (e *Expr) Evaluate() interface{} {
 	return e.op(e.left, e.right)
 }
 
+func (e *Expr) Op() Operator {
+	return e.op
+}
+
+func (e *Expr) Left() Expression {
+	return e.left
+}
+
+func (e *Expr) Right() Expression {
+	return e.right
+}
+
+func (e *Expr) SetOp(op Operator) {
+	e.op = op
+}
+
+func (e *Expr) SetRight(expr Expression) {
+	e.right = expr
+}
+
+func (e *Expr) SetLeft(expr Expression) {
+	e.left = expr
+}
+
 func (s *StructExpr) Evaluate() interface{} {
 	// Parse out struct name here.
 	head := ""

--- a/decide.go
+++ b/decide.go
@@ -91,7 +91,7 @@ func NewPrimitive(val interface{}) *Primitive {
 }
 
 // Decide is meant to kick off a decision using a root Expr.
-func Decide(expr *Expr) bool {
+func Decide(expr Expression) bool {
 	eval := expr.Evaluate()
 	result, ok := eval.(bool)
 	// For now assume that results that aren't bools evaluate to false.

--- a/init.go
+++ b/init.go
@@ -33,5 +33,7 @@ func init() {
 		">=": Gteq,
 		"<=": Lteq,
 		"~=": Matches,
+		"&&": And,
+		"||": Or,
 	}
 }

--- a/init.go
+++ b/init.go
@@ -1,0 +1,37 @@
+package decide
+
+// init handle setting up a default lexer and parser.
+func init() {
+	lexer = &Lexer{}
+
+	lexer.Specials = map[string]bool{
+		"=": true,
+		"<": true,
+		">": true,
+		"!": true,
+		"~": true,
+		"&": true,
+		"|": true,
+	}
+
+	lexer.Delims = map[string]bool{
+		" ": true,
+	}
+
+	lexer.Scopes = map[string]bool{
+		"(": true,
+		")": true,
+	}
+
+	parser = &Parser{}
+
+	parser.Ops = map[string]Operator{
+		"=":  Eq,
+		"!=": Neq,
+		">":  Gt,
+		"<":  Lt,
+		">=": Gteq,
+		"<=": Lteq,
+		"~=": Matches,
+	}
+}

--- a/lexer.go
+++ b/lexer.go
@@ -1,0 +1,127 @@
+package decide
+
+import "log"
+
+type Lexer struct {
+	Specials map[string]bool
+	Delims   map[string]bool
+	Scopes   map[string]bool
+}
+
+var lexer *Lexer
+
+func init() {
+	lexer = &Lexer{}
+
+	lexer.Specials = map[string]bool{
+		"=": true,
+		"<": true,
+		">": true,
+		"!": true,
+		"~": true,
+		"&": true,
+		"|": true,
+	}
+
+	lexer.Delims = map[string]bool{
+		" ": true,
+	}
+
+	lexer.Scopes = map[string]bool{
+		"(": true,
+		")": true,
+	}
+}
+
+func GetLexer() *Lexer {
+	return lexer
+}
+
+func (l *Lexer) Lex(target string) []string {
+	var haveSpecial bool
+	length := len(target)
+	if length == 0 {
+		return nil
+	}
+	var start int
+	var index int
+	result := make([]string, length)
+
+	for i := 0; i < len(target); i++ {
+		log.Printf("Evaluating char: %s", string(target[i]))
+		if isDelim(string(target[i])) {
+			if start != i {
+				log.Printf("Saving word: %s$", string(target[start:i]))
+				result[index] = string(target[start:i])
+				index++
+			}
+			start = i + 1
+			continue
+		}
+
+		if isScope(string(target[i])) {
+			log.Println("FOUND PAREN")
+			log.Printf("INDEX IS: %d", index)
+			if start != i {
+				log.Printf("Saving word: %s$", string(target[start:i]))
+				result[index] = string(target[start:i])
+				index++
+			}
+			log.Printf("SAVING PAREN: %s")
+			result[index] = string(target[i])
+			start = i + 1
+			index++
+			continue
+		}
+
+		if isSpecial(string(target[i])) {
+			if !haveSpecial {
+				if start != i {
+					log.Printf("Saving word: %s$", string(target[start:i]))
+					result[index] = string(target[start:i])
+					start = i
+					index++
+				}
+
+				if i == len(target)-1 {
+					result[index] = string(target[i])
+				}
+
+				haveSpecial = true
+			}
+			continue
+		}
+
+		if haveSpecial {
+			if start != i {
+				log.Printf("Saving word: %s$", string(target[start:i]))
+				result[index] = string(target[start:i])
+				start = i
+				index++
+			}
+		}
+
+		if i == len(target)-1 {
+			result[index] = string(target[start:len(target)])
+		}
+		haveSpecial = false
+	}
+
+	// It's faster to grab a subslice at the end then continuously append.
+	return result[0:index]
+}
+
+func isSpecial(char string) bool {
+	_, ok := lexer.Specials[char]
+	return ok
+}
+
+func isDelim(char string) bool {
+	_, ok := lexer.Delims[char]
+	return ok
+}
+
+func isScope(char string) bool {
+	_, ok := lexer.Scopes[char]
+	return ok
+}

--- a/lexer.go
+++ b/lexer.go
@@ -114,6 +114,7 @@ func (l *Lexer) Lex(target string) []string {
 
 		if i == len(target)-1 {
 			result[index] = string(target[start:len(target)])
+			index++
 		}
 		haveSpecial = false
 	}

--- a/lexer.go
+++ b/lexer.go
@@ -39,6 +39,7 @@ func GetLexer() *Lexer {
 
 func (l *Lexer) Lex(target string) []string {
 	var haveSpecial bool
+	var inString bool
 	length := len(target)
 	if length == 0 {
 		return nil
@@ -49,6 +50,26 @@ func (l *Lexer) Lex(target string) []string {
 
 	for i := 0; i < len(target); i++ {
 		log.Printf("Evaluating char: %s", string(target[i]))
+		if string(target[i]) == "\"" {
+			if inString {
+				if isEscaped(target, i) {
+					continue
+				}
+
+				inString = false
+				result[index] = string(target[start : i+1])
+				index++
+				start = i + 1
+				continue
+			}
+			inString = true
+			start = i
+		}
+
+		if inString {
+			continue
+		}
+
 		if isDelim(string(target[i])) {
 			if start != i {
 				log.Printf("Saving word: %s$", string(target[start:i]))
@@ -124,4 +145,11 @@ func isDelim(char string) bool {
 func isScope(char string) bool {
 	_, ok := lexer.Scopes[char]
 	return ok
+}
+
+func isEscaped(source string, index int) bool {
+	if string(source[index-1]) == "\\" {
+		return true
+	}
+	return false
 }

--- a/lexer.go
+++ b/lexer.go
@@ -1,7 +1,5 @@
 package decide
 
-import "log"
-
 type Lexer struct {
 	Specials map[string]bool
 	Delims   map[string]bool
@@ -49,7 +47,6 @@ func (l *Lexer) Lex(target string) []string {
 	result := make([]string, length)
 
 	for i := 0; i < len(target); i++ {
-		log.Printf("Evaluating char: %s", string(target[i]))
 		if string(target[i]) == "\"" {
 			if inString {
 				if isEscaped(target, i) {
@@ -72,7 +69,6 @@ func (l *Lexer) Lex(target string) []string {
 
 		if isDelim(string(target[i])) {
 			if start != i {
-				log.Printf("Saving word: %s$", string(target[start:i]))
 				result[index] = string(target[start:i])
 				index++
 			}
@@ -81,14 +77,10 @@ func (l *Lexer) Lex(target string) []string {
 		}
 
 		if isScope(string(target[i])) {
-			log.Println("FOUND PAREN")
-			log.Printf("INDEX IS: %d", index)
 			if start != i {
-				log.Printf("Saving word: %s$", string(target[start:i]))
 				result[index] = string(target[start:i])
 				index++
 			}
-			log.Printf("SAVING PAREN: %s")
 			result[index] = string(target[i])
 			start = i + 1
 			index++
@@ -98,7 +90,6 @@ func (l *Lexer) Lex(target string) []string {
 		if isSpecial(string(target[i])) {
 			if !haveSpecial {
 				if start != i {
-					log.Printf("Saving word: %s$", string(target[start:i]))
 					result[index] = string(target[start:i])
 					start = i
 					index++
@@ -115,7 +106,6 @@ func (l *Lexer) Lex(target string) []string {
 
 		if haveSpecial {
 			if start != i {
-				log.Printf("Saving word: %s$", string(target[start:i]))
 				result[index] = string(target[start:i])
 				start = i
 				index++

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -1,0 +1,28 @@
+package decide_test
+
+import (
+	"testing"
+
+	"github.com/eriktate/go-decide"
+)
+
+func Test_Lex(t *testing.T) {
+	t.Log("BEGINNING LEXER TEST")
+	lexer := decide.GetLexer()
+
+	testString := "(10 = 10)"
+	tokens := lexer.Lex(testString)
+
+	t.Logf("Lexer tokens: %+v", tokens)
+	if len(tokens) != 5 {
+		t.Errorf("Lexer pulled incorrect number of tokens: %d", len(tokens))
+	}
+
+	testString2 := "(((5 > 2) && (var1 = var2)) != true)"
+	tokens = lexer.Lex(testString2)
+
+	t.Logf("Lexer tokens: %+v", tokens)
+	if len(tokens) != 17 {
+		t.Errorf("Lexer pulled incorrect number of tokens: %d", len(tokens))
+	}
+}

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -25,4 +25,12 @@ func Test_Lex(t *testing.T) {
 	if len(tokens) != 17 {
 		t.Errorf("Lexer pulled incorrect number of tokens: %d", len(tokens))
 	}
+
+	stringTest := "(\"hello\" != \"world\")"
+	tokens = lexer.Lex(stringTest)
+
+	t.Logf("Lexer tokens: %+v", tokens)
+	if len(tokens) != 5 {
+		t.Errorf("Lexer pulled incorrect number of tokens: %d", len(tokens))
+	}
 }

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -10,16 +10,16 @@ func Test_Lex(t *testing.T) {
 	t.Log("BEGINNING LEXER TEST")
 	lexer := decide.GetLexer()
 
-	testString := "(10 = 10)"
-	tokens := lexer.Lex(testString)
+	basicExpr := "(10 = 10)"
+	tokens := lexer.Lex(basicExpr)
 
 	t.Logf("Lexer tokens: %+v", tokens)
 	if len(tokens) != 5 {
 		t.Errorf("Lexer pulled incorrect number of tokens: %d", len(tokens))
 	}
 
-	testString2 := "(((5 > 2) && (var1 = var2)) != true)"
-	tokens = lexer.Lex(testString2)
+	complexExpr := "(((5 > 2) && (var1 = var2)) != true)"
+	tokens = lexer.Lex(complexExpr)
 
 	t.Logf("Lexer tokens: %+v", tokens)
 	if len(tokens) != 17 {
@@ -28,6 +28,14 @@ func Test_Lex(t *testing.T) {
 
 	stringTest := "(\"hello\" != \"world\")"
 	tokens = lexer.Lex(stringTest)
+
+	t.Logf("Lexer tokens: %+v", tokens)
+	if len(tokens) != 5 {
+		t.Errorf("Lexer pulled incorrect number of tokens: %d", len(tokens))
+	}
+
+	escapedTest := "(\"testing \\\" char\" != \"other test\")"
+	tokens = lexer.Lex(escapedTest)
 
 	t.Logf("Lexer tokens: %+v", tokens)
 	if len(tokens) != 5 {

--- a/ops.go
+++ b/ops.go
@@ -2,7 +2,6 @@ package decide
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 	"regexp"
 )
@@ -72,14 +71,11 @@ func Matches(left, right Expression) bool {
 	var rightPattern string
 	var ok bool
 
-	log.Println("HIT MATCHES")
 	if leftPattern, ok = left.Evaluate().(string); !ok {
-		log.Println("LEFT SIDE NOT STRING")
 		return false
 	}
 
 	if rightPattern, ok = right.Evaluate().(string); !ok {
-		log.Println("RIGHT SIDE NOT STRING")
 		return false
 	}
 
@@ -87,16 +83,13 @@ func Matches(left, right Expression) bool {
 	// Otherwise, if the left side is a regex we test that pattern against the right.
 	r, err := compileRegex(rightPattern)
 	if err != nil {
-		log.Println("RIGHT SIDE NOT REGEX")
 		r, err := compileRegex(leftPattern)
 		if err != nil {
-			log.Println("LEFT SIDE NOT REGEX")
 			// if neither argument is a pattern, test for equality.
 			return Eq(left, right)
 		}
 		return r.Match([]byte(rightPattern))
 	}
-	log.Println("RIGHT SIDE IS REGEX")
 	return r.MatchString(leftPattern)
 }
 

--- a/ops_test.go
+++ b/ops_test.go
@@ -156,3 +156,48 @@ func Test_Lt(t *testing.T) {
 		t.Errorf("Truthy expression resulted in false.")
 	}
 }
+
+func Test_Matches(t *testing.T) {
+	// SETUP FOR SUCCESS
+	t.Log("SETTING UP FOR MATCHES SUCCESS")
+	left := decide.NewPrimitive("this is a test")
+	right := decide.NewPrimitive("/.*(test).*/")
+
+	// TEST FOR SUCCESS
+	t.Log("TESTING MATCHES FOR SUCCESS")
+	result1 := decide.Matches(left, right)
+	result2 := decide.Matches(right, left)
+	result3 := decide.Matches(decide.NewPrimitive("test"), decide.NewPrimitive("test"))
+
+	// ASSERT SUCCESS
+	t.Logf("RESULT1 WAS %t", result1)
+	t.Logf("RESULT2 WAS %t", result2)
+	t.Logf("RESULT3 WAS %t", result3)
+
+	if !result1 {
+		t.Errorf("Truthy expression resulted in false")
+	}
+
+	if !result2 {
+		t.Errorf("Truthy expression resulted in false")
+	}
+
+	if !result3 {
+		t.Errorf("Truthy expression resulted in false")
+	}
+
+	// SETUP FOR FAILURE
+	t.Logf("SETTING UP FOR MATCHES FAILURE")
+	left = decide.NewPrimitive("this is a test")
+	right = decide.NewPrimitive("/.*(not a test).*/")
+
+	// TEST FOR FAILURE
+	t.Log("TESTING MATCHES FOR FAILURE")
+	result := decide.Matches(left, right)
+
+	t.Logf("RESULT WAS %t", result)
+
+	if result {
+		t.Errorf("Falsey expression resulted in true")
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -1,5 +1,11 @@
 package decide
 
+import (
+	"fmt"
+	"log"
+	"strconv"
+)
+
 type Parser struct {
 	Ops map[string]Operator
 }
@@ -14,13 +20,103 @@ func GetParser() *Parser {
 // Parse is the primary method of parsing tokens into an Expression that can be
 // evaluated. It provides a nicer API than subParse which does all of the actual work.
 func (p *Parser) Parse(tokens []string) (*Expr, error) {
-	expr, idx, err := p.subParse(tokens, 0)
+	expr, _, err := p.subParse(tokens, 0)
 	return expr, err
 }
 
 // subParse handles all of the heavy lifting involved with parsing tokens into Expressions.
 // It recursively explores a given slice of tokens and returns the resulting expression,
 // index it left off at and any error that may have occurred during the process.
-func (p *Parser) subParse(tokens []string, idx int) {
+func (p *Parser) subParse(tokens []string, idx int) (*Expr, int, error) {
+	log.Printf("PARSING TOKENS %+v", tokens)
+	expr := &Expr{}
 
+	for i := idx; i < len(tokens); i++ {
+		var val Expression
+		token := tokens[i]
+
+		// check if a there's a new expression.
+		if isNewScope(token) {
+			e, index, err := p.subParse(tokens, i+1)
+			val = e
+			// NOTE: This isn't great practice, but it helps prevent multiple passes being required.
+			i = index
+			if err != nil {
+				return expr, i, err
+			}
+			continue
+		}
+
+		if isClosingScope(token) {
+			return expr, i, nil
+		}
+
+		if op, ok := p.Ops[token]; ok {
+			log.Println("FOUND OP")
+			expr.SetOp(op)
+			continue
+		}
+
+		if val == nil {
+			log.Println("val is nil!")
+			var err error
+			val, err = castTokenAsExpr(token)
+			if err != nil {
+				return nil, i + 1, err
+			}
+		} else {
+			log.Println("val is not nil")
+		}
+
+		if expr.Op() != nil {
+			log.Println("SETTING RIGHT EXPRESSION")
+			expr.SetRight(val)
+		} else {
+			log.Println("SETTING LEFT EXPRESSION")
+			expr.SetLeft(val)
+		}
+	}
+
+	return expr, len(tokens), nil
+}
+
+func castTokenAsExpr(token string) (Expression, error) {
+	str, err := parseString(token)
+	if err == nil {
+		log.Println("FOUND STRING")
+		return NewPrimitive(str), nil
+	}
+
+	num, err := parseFloat(token)
+	if err == nil {
+		log.Println("FOUND NUMBER")
+		return NewPrimitive(num), nil
+	}
+
+	return nil, fmt.Errorf("Couldn't parse type. Missing parser for %s", token)
+}
+
+func isNewScope(token string) bool {
+	if token == "(" {
+		return true
+	}
+	return false
+}
+
+func isClosingScope(token string) bool {
+	if token == ")" {
+		return true
+	}
+	return false
+}
+
+func parseString(token string) (string, error) {
+	if string(token[0]) == "\"" && string(token[len(token)-1]) == "\"" {
+		return string(token[1 : len(token)-1]), nil
+	}
+	return "", fmt.Errorf("Value is a not a string")
+}
+
+func parseFloat(token string) (float64, error) {
+	return strconv.ParseFloat(token, 64)
 }

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,3 @@
+package decide
+
+type Parser struct{}

--- a/parser.go
+++ b/parser.go
@@ -1,3 +1,7 @@
 package decide
 
-type Parser struct{}
+type Parser struct {
+	Ops map[string]Operator
+}
+
+var parser *Parser

--- a/parser.go
+++ b/parser.go
@@ -5,3 +5,22 @@ type Parser struct {
 }
 
 var parser *Parser
+
+// GetParser returns the default go-decide parser.
+func GetParser() *Parser {
+	return parser
+}
+
+// Parse is the primary method of parsing tokens into an Expression that can be
+// evaluated. It provides a nicer API than subParse which does all of the actual work.
+func (p *Parser) Parse(tokens []string) (*Expr, error) {
+	expr, idx, err := p.subParse(tokens, 0)
+	return expr, err
+}
+
+// subParse handles all of the heavy lifting involved with parsing tokens into Expressions.
+// It recursively explores a given slice of tokens and returns the resulting expression,
+// index it left off at and any error that may have occurred during the process.
+func (p *Parser) subParse(tokens []string, idx int) {
+
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -9,17 +9,31 @@ import (
 func Test_BasicParse(t *testing.T) {
 	// SETUP FOR SUCCESS
 	t.Log("SETTING UP FOR PARSE SUCCESS")
-	ex := "10 = 10"
+
+	ex1 := "10 = 10"
+	ex2 := "(12 > 8)"
+	ex3 := "(12 > 5) && (\"hello\" != \"world\")"
+
 	parser := decide.GetParser()
 	lexer := decide.GetLexer()
 
-	result, err := parser.Parse(lexer.Lex(ex))
+	result1, err := parser.Parse(lexer.Lex(ex1))
+	result2, err := parser.Parse(lexer.Lex(ex2))
+	result3, err := parser.Parse(lexer.Lex(ex3))
 
 	if err != nil {
 		t.Error(err)
 	}
 
-	if !decide.Decide(result) {
+	if !decide.Decide(result1) {
+		t.Error("Truthy expression resulted in false")
+	}
+
+	if !decide.Decide(result2) {
+		t.Error("Truthy expression resulted in false")
+	}
+
+	if !decide.Decide(result3) {
 		t.Error("Truthy expression resulted in false")
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,7 +1,25 @@
 package decide_test
 
-import "testing"
+import (
+	"testing"
 
-func Test_Something(t *testing.T) {
-	t.Log("Hello sweetie")
+	decide "github.com/eriktate/go-decide"
+)
+
+func Test_BasicParse(t *testing.T) {
+	// SETUP FOR SUCCESS
+	t.Log("SETTING UP FOR PARSE SUCCESS")
+	ex := "(10 = 10)"
+	parser := decide.GetParser()
+	lexer := decide.GetLexer()
+
+	result, err := parser.Parse(lexer.Lex(ex))
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !result {
+		t.Error("Truthy expression resulted in false")
+	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -9,7 +9,7 @@ import (
 func Test_BasicParse(t *testing.T) {
 	// SETUP FOR SUCCESS
 	t.Log("SETTING UP FOR PARSE SUCCESS")
-	ex := "(10 = 10)"
+	ex := "10 = 10"
 	parser := decide.GetParser()
 	lexer := decide.GetLexer()
 
@@ -19,7 +19,7 @@ func Test_BasicParse(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !result {
+	if !decide.Decide(result) {
 		t.Error("Truthy expression resulted in false")
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,7 @@
+package decide_test
+
+import "testing"
+
+func Test_Something(t *testing.T) {
+	t.Log("Hello sweetie")
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -13,14 +13,20 @@ func Test_BasicParse(t *testing.T) {
 	ex1 := "10 = 10"
 	ex2 := "(12 > 8)"
 	ex3 := "(12 > 5) && (\"hello\" != \"world\")"
+	forFun := "\"does this work\" ~= \"/.*(work).*/\""
 
 	parser := decide.GetParser()
 	lexer := decide.GetLexer()
 
+	// TESTING FOR SUCCESS
+	t.Log("TESTING PARSE FOR SUCCESS")
 	result1, err := parser.Parse(lexer.Lex(ex1))
 	result2, err := parser.Parse(lexer.Lex(ex2))
 	result3, err := parser.Parse(lexer.Lex(ex3))
+	funResult, err := parser.Parse(lexer.Lex(forFun))
 
+	// ASSERT SUCCESS
+	t.Log("ASSERTING SUCCESS")
 	if err != nil {
 		t.Error(err)
 	}
@@ -34,6 +40,10 @@ func Test_BasicParse(t *testing.T) {
 	}
 
 	if !decide.Decide(result3) {
+		t.Error("Truthy expression resulted in false")
+	}
+
+	if !decide.Decide(funResult) {
 		t.Error("Truthy expression resulted in false")
 	}
 }


### PR DESCRIPTION
This PR adds the ability to parse strings into expressions that can be evaluated. For the time being this only applies to primitive strings and numbers.

In order evaluate a string as an expression, you need to first lex the string into tokens and then run those tokens through a parser. Default implementations of both are available, but these should be extensible and customizable in the future.

E.g.
```go
lexer := decide.GetLexer()
parser := decide.GetParser()
exString := "10 > 5"

expr, _ := parser.Parse(lexer.Lex(exString))
result := decide.Decide(expr) // bool result
```

The naming and specifics around how these APIs work is likely to change in the future. I'm mostly not crazy about all of the repetition (lexer.Lex, parser.Parse, decide.Decide). For now though, everything seems to be working properly.